### PR TITLE
WIP: contributing to the presentation

### DIFF
--- a/docs/at.qmd
+++ b/docs/at.qmd
@@ -1,0 +1,35 @@
+# `at`: Do it, but only once!
+
+## Overview
+
+- Part of most Unix-like distros
+- Schedule a task at a specific moment
+- Executes only once
+- Companion utilities: `batch`, `atq`, `atrm`
+- Use `-M` to suppress sending mails
+
+## Syntax
+
+```bash
+# interactive mode
+at [options] runtime
+```
+
+Accepted (suggested) formats for `runtime` are:
+
+- `HH:MM` or `HHMM`
+- `now`, `noon`, `midnight`, `teatime` (16:00)
+- `HH:MM YY-MM-DD`
+- and more. See [at man page](https://linux.die.net/man/1/at)
+
+## Example
+
+```bash
+# execute a shell script
+at 13:08 24-08-06 -M -f $VSC_DATA/cronjobs/accountinfo.sh 
+# list scheduled tasks
+at -l
+3       Tue Aug  6 13:08:00 2024 a vsc30745
+# delete task by its id
+at -d 3
+```

--- a/docs/crontab.qmd
+++ b/docs/crontab.qmd
@@ -1,0 +1,41 @@
+# `crontab`: Native Linux Scheduler
+
+## Overview
+
+- Similar to `at`, but repeats a task
+- Part of most Unix-like distros
+- Supported at VSC sites
+- Suitable for light-weight tasks (sysadmin always uses it)
+- Can run on the login node (no job)
+
+```bash
+crontab -l   # lists all scheduled cronjobs
+crontab -e   # edit 
+crontab -r   # remove
+```
+
+## Syntax
+
+```bash
+SHELL = /bin/bash
+MYVAR = foo
+
+* * * * * command to be executed
+– – – – –
+| | | | |
+| | | | +—– day of week (0 – 6) (Sunday=0)
+| | | +——- month (1 – 12)
+| | +——— day of month (1 – 31)
+| +———– hour (0 – 23)
++————- min (0 – 59)
+```
+Or simply
+```bash
+@daily $VSC_DATA/cronjobs/run_pipeline.sh
+```
+
+## Example
+
+```bash
+@weekly $VSC_DATA/tests/crontab/accountinfo.sh
+```

--- a/docs/slurm_workflows.qmd
+++ b/docs/slurm_workflows.qmd
@@ -2,7 +2,7 @@
 
 ## Overview
 
-By itself, Slurm offers "workflow capabilities
+By itself, Slurm offers "workflow capabilities"
 
 - running jobs at regular intervals: `scrontab`
 - job depencencies

--- a/docs/workflows_for_hpc_lunchbox.qmd
+++ b/docs/workflows_for_hpc_lunchbox.qmd
@@ -21,4 +21,6 @@ Topic covered:
   - Globus
   - iRODS
 
+{{< include at.qmd >}}
+{{< include crontab.qmd >}}
 {{< include slurm_workflows.qmd >}}


### PR DESCRIPTION
This PR adds additional Quarto pages to the presentation template inside `docs` folder. More specificcally:
- [x] `at` is included
- [ ] `crontab` is included
- [ ] `scrontab` is included