### PR TITLE
Add non-trivial atools reduction example

### DIFF
--- a/source-code/atools/README.md
+++ b/source-code/atools/README.md
@@ -12,3 +12,5 @@ Some examples of how to use atools.
 1. `openmp`: example of running an array job of an OpenMP application.
 1. `mpi`: example of running an array job of an MPI application.
 1. `random_failures`: example of an atools job with failing work items.
+1. `reductor`: example of a non-trivial reductor script, as well as multi-level
+   parallelism using GNU parallel.

--- a/source-code/atools/reductor/.gitignore
+++ b/source-code/atools/reductor/.gitignore
@@ -1,0 +1,4 @@
+text.txt
+*.bin
+data/
+processed-data/

--- a/source-code/atools/reductor/README.md
+++ b/source-code/atools/reductor/README.md
@@ -1,0 +1,51 @@
+# Reductor
+
+Illustration of a non-trivial reductor.  A text file is parsed by line, and a
+dictionary of words and their counts is produced.  When done in parallel, each
+work item will produce its own dictionary that is saved as a pickle file.  The
+reductor will aggregate the data into a single pickle file.
+
+
+## What is it?
+
+1. `data_generator.py`: generate a simple text file suitable for parsing and
+   word count.  The file can be arbitrary large.
+1. `counter.py`: reads a text file from a specified line up to and not
+   including a specified last line (0-based, same semantics as Python's `range`
+   function.  The result is a pickle file representing the `dict` for this text
+   fragment.
+1. `pickle_empty.py`: create a pickle file for an empty `dict`.
+1. `pickle_update.py`: takes two tickle files as arguments, and add the
+   contents of the second to the first.
+1. `pickle_diff.py`: compare two pickle files, and print differences.
+
+
+## How to use?
+
+To create a text file with 100 lines, 20 words per line:
+```bash
+$ ./data_generator.py --lines 100 --words_per_line 20 > text.txt
+```
+
+To count words in the text fragment from, e.g., line 0 to line 10
+(non-inclusive), and produce a pickle file `count_01.bin`:
+```bash
+$ ./counter.py text.txt --start 0 --end 10 count_01.bin
+```
+To count words in the text fragment for the next 10 lines, and produce
+a pickle file `count_02.bin`:
+```bash
+$ ./counter.py text.txt --start 10 --end 20 count_02.bin
+```
+
+To combine the pickle files, first create one containing an empty `dict`:
+```bash
+$ ./pickle_empty count_aggr.bin
+```
+Next, aggragate all the pickle files into `count_aggr.bin`:
+```bash
+for file in $(ls count_[0-9]*.bin)
+do
+    ./pickle_update.py count_aggr.bin $file
+done
+```

--- a/source-code/atools/reductor/README.md
+++ b/source-code/atools/reductor/README.md
@@ -25,6 +25,18 @@ reductor will aggregate the data into a single pickle file.
 1. `pickle_diff.py`: compare two pickle files, and print differences.
 
 
+## `areduce`
+
+When the processing is done, the results are in multiple pickle files.  To
+aggregate them into a single pickle file, use the `areduce` command.
+
+```bash
+$ areduce  -t 1-100  --pattern `processed-data/file-{t}.bin \
+      --empty pickle_empty.py  --reduce pickle_update.py    \
+      --out final_count.bin
+```
+
+
 ## How to use?
 
 To create a text file with 100 lines, 20 words per line:

--- a/source-code/atools/reductor/README.md
+++ b/source-code/atools/reductor/README.md
@@ -10,11 +10,16 @@ reductor will aggregate the data into a single pickle file.
 
 1. `data_generator.py`: generate a simple text file suitable for parsing and
    word count.  The file can be arbitrary large.
+1. `generate_data.sh`: Bash script that generates data files in a directory `data/`.
 1. `counter.py`: reads a text file from a specified line up to and not
    including a specified last line (0-based, same semantics as Python's `range`
    function.  The result is a pickle file representing the `dict` for this text
    fragment.
-1. `pickle_empty.py`: create a pickle file for an empty `dict`.
+1. `counter.slurm`: Slurm job script to run `counter.py` using GNU parallel;
+   illustrates multi-level parallelism when submitted as a job array.
+1. `pickle_empty.py`: create a pickle file for an empty `dict`.  Note that this
+    script ignores all but the first positional argument, which is the output
+    pickle file name.
 1. `pickle_update.py`: takes two tickle files as arguments, and add the
    contents of the second to the first.
 1. `pickle_diff.py`: compare two pickle files, and print differences.
@@ -48,4 +53,4 @@ for file in $(ls count_[0-9]*.bin)
 do
     ./pickle_update.py count_aggr.bin $file
 done
-```
+g``

--- a/source-code/atools/reductor/counter.py
+++ b/source-code/atools/reductor/counter.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+from argparse import ArgumentParser
+import pickle
+import sys
+
+
+if __name__ == '__main__':
+    arg_parser = ArgumentParser(description='count words in file, and '
+                                            'output dict as picle file')
+    arg_parser.add_argument('input', help='file to parse')
+    arg_parser.add_argument('--start', type=int, default=0,
+                            help='first line to read (0-based)')
+    arg_parser.add_argument('--end', type=int, default=1000000000,
+                            help='last line to read, not inclusive '
+                                 '(0-based)')
+    arg_parser.add_argument('output', help='name of pickle output file')
+    arg_parser.add_argument('--verbose', action='store_true',
+                            help='verbose output')
+    options = arg_parser.parse_args()
+    count = {}
+    with open(options.input, 'r') as in_file:
+        for line_nr in range(options.start):
+            _ = in_file.readline()
+        for line_nr in range(options.start, options.end):
+            line = in_file.readline().rstrip()
+            if not line:
+                break
+            if options.verbose:
+                print(f'processing line {line_nr}', file=sys.stderr)
+            for word in line.split():
+                if word not in count:
+                    count[word] = 0
+                count[word] += 1
+    with open(options.output, 'wb') as out_file:
+        pickle.dump(count, out_file)

--- a/source-code/atools/reductor/counter.slurm
+++ b/source-code/atools/reductor/counter.slurm
@@ -7,4 +7,6 @@
 start_value=$SLURM_ARRAY_TASK_ID
 end_value=$(( SLURM_ARRAY_TASK_ID + SLURM_ARRAY_TASK_STEP ))
 
+mkdir -p processed-data/
+
 parallel --max-procs $SLURM_NTASKS ./counter.py data/file-{}.txt processed-data/file-{}.bin ::: $(seq $start_value $end_value)

--- a/source-code/atools/reductor/counter.slurm
+++ b/source-code/atools/reductor/counter.slurm
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S bash -l
+#SBATCH --account=lpt2_sysadmin
+#SBATCH --cluster=wice
+#SBATCH --ntasks=4
+#SBATCH --time=00:10:00
+
+start_value=$SLURM_ARRAY_TASK_ID
+end_value=$(( SLURM_ARRAY_TASK_ID + SLURM_ARRAY_TASK_STEP ))
+
+parallel --max-procs $SLURM_NTASKS ./counter.py data/file-{}.txt processed-data/file-{}.bin ::: $(seq $start_value $end_value)

--- a/source-code/atools/reductor/data_generator.py
+++ b/source-code/atools/reductor/data_generator.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+from argparse import ArgumentParser
+import random
+import string
+
+
+if __name__ == '__main__':
+    arg_parser = ArgumentParser(description='generate random text file')
+    arg_parser.add_argument('--lines', type=int, default=10,
+                            help='number of lines to generate')
+    arg_parser.add_argument('--words_per_line', type=int, default=15,
+                            help='number of words per line')
+    arg_parser.add_argument('--word_length', type=int, default=3,
+                            help='word length')
+    options = arg_parser.parse_args()
+    for _ in range(options.lines):
+        words = []
+        for _ in range(options.words_per_line):
+            word = ''
+            for _ in range(options.word_length):
+                word += random.choice(string.ascii_lowercase)
+            words.append(word)
+        print(' '.join(words))

--- a/source-code/atools/reductor/generate_data.sh
+++ b/source-code/atools/reductor/generate_data.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+mkdir -p data/
+
+for i in $(seq 100)
+do
+      ./data_generator.py --lines 100000 --words_per_line 45 > "data/file-${i}.txt"
+done

--- a/source-code/atools/reductor/pickle_diff.py
+++ b/source-code/atools/reductor/pickle_diff.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+from argparse import ArgumentParser
+import pickle
+
+if __name__ == '__main__':
+    arg_parser = ArgumentParser(description='compare two pickle files '
+                                            'storing a dict')
+    arg_parser.add_argument('left', help='first pickle file')
+    arg_parser.add_argument('right', help='second pickle file')
+    options = arg_parser.parse_args()
+    with open(options.left, 'rb') as left_file:
+        left_dict = pickle.load(left_file)
+    with open(options.right, 'rb') as right_file:
+        right_dict = pickle.load(right_file)
+    left_words = set(left_dict.keys())
+    right_words = set(right_dict.keys())
+    left_only = left_words - right_words
+    for word in left_only:
+        print('< {word:s}: {count:10d}'.format(word=word,
+                                               count=left_dict[word]))
+    common = left_words.intersection(right_words)
+    fmt_str = '{word:s}: <{l_count:10d} >{r_count:10d}'
+    for word in common:
+        if left_dict[word] != right_dict[word]:
+            print(fmt_str.format(word=word, l_count=left_dict[word],
+                                 r_count=right_dict[word]))
+    right_only = right_words - left_words
+    for word in right_only:
+        print('< {word:s}: {count:10d}'.format(word=word,
+                                               count=right_dict[word]))

--- a/source-code/atools/reductor/pickle_diff.py
+++ b/source-code/atools/reductor/pickle_diff.py
@@ -15,17 +15,10 @@ if __name__ == '__main__':
         right_dict = pickle.load(right_file)
     left_words = set(left_dict.keys())
     right_words = set(right_dict.keys())
-    left_only = left_words - right_words
-    for word in left_only:
-        print('< {word:s}: {count:10d}'.format(word=word,
-                                               count=left_dict[word]))
-    common = left_words.intersection(right_words)
-    fmt_str = '{word:s}: <{l_count:10d} >{r_count:10d}'
-    for word in common:
+    for word in left_words - right_words:
+        print(f'< {word}: {left_dict[word]}')
+    for word in left_words & right_words:
         if left_dict[word] != right_dict[word]:
-            print(fmt_str.format(word=word, l_count=left_dict[word],
-                                 r_count=right_dict[word]))
-    right_only = right_words - left_words
-    for word in right_only:
-        print('< {word:s}: {count:10d}'.format(word=word,
-                                               count=right_dict[word]))
+            print(f'{word}: <{left_dict[word]} >{right_dict[word]}')
+    for word in right_words - left_words:
+        print(f'< {word}: {right_dict[word]}')

--- a/source-code/atools/reductor/pickle_empty.py
+++ b/source-code/atools/reductor/pickle_empty.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+from argparse import ArgumentParser
+import pickle
+
+if __name__ == '__main__':
+    arg_parser = ArgumentParser(description='create pickle file of empty '
+                                            'dictionary')
+    arg_parser.add_argument('out', help='name of the pickle file')
+    options = arg_parser.parse_args()
+    counter = dict()
+    with open(options.out, 'wb') as out_file:
+        pickle.dump(counter, out_file)

--- a/source-code/atools/reductor/pickle_empty.py
+++ b/source-code/atools/reductor/pickle_empty.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from argparse import ArgumentParser
 import pickle
@@ -7,7 +7,7 @@ if __name__ == '__main__':
     arg_parser = ArgumentParser(description='create pickle file of empty '
                                             'dictionary')
     arg_parser.add_argument('out', help='name of the pickle file')
-    options = arg_parser.parse_args()
-    counter = dict()
+    options, _ = arg_parser.parse_known_args()
+    counter = {}
     with open(options.out, 'wb') as out_file:
         pickle.dump(counter, out_file)

--- a/source-code/atools/reductor/pickle_update.py
+++ b/source-code/atools/reductor/pickle_update.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+from argparse import ArgumentParser
+import pickle
+
+if __name__ == '__main__':
+    arg_parser = ArgumentParser(description='create new pickle file from '
+                                            'two existing files')
+    arg_parser.add_argument('old', help='name of aggregation pickle file')
+    arg_parser.add_argument('new', help='name of pickel file to add to '
+                                        'aggregation')
+    options = arg_parser.parse_args()
+    with open(options.old, 'rb') as old_file:
+        old_data = pickle.load(old_file)
+    with open(options.new, 'rb') as new_file:
+        new_data = pickle.load(new_file)
+    for word, count in new_data.iteritems():
+        if word in old_data:
+            old_data[word] += count
+        else:
+            old_data[word] = count
+    with open(options.old, 'wb') as old_file:
+        pickle.dump(old_data, old_file)

--- a/source-code/atools/reductor/pickle_update.py
+++ b/source-code/atools/reductor/pickle_update.py
@@ -14,7 +14,7 @@ if __name__ == '__main__':
         old_data = pickle.load(old_file)
     with open(options.new, 'rb') as new_file:
         new_data = pickle.load(new_file)
-    for word, count in new_data.iteritems():
+    for word, count in new_data.items():
         if word in old_data:
             old_data[word] += count
         else:


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new non-trivial reduction example for atools showcasing dictionary-based word-count aggregation via pickle files and multi-level parallelism.

New Features:
- Add a "reductor" example demonstrating word-count reduction with multi-level parallelism using GNU parallel and areduce.
- Provide supporting scripts and tools: data_generator.py, counter.py, pickle_empty.py, pickle_update.py, pickle_diff.py, generate_data.sh, and counter.slurm.

Documentation:
- Update the atools README to reference the new reductor example.
- Add a detailed README for the reductor directory explaining setup and usage.